### PR TITLE
Update min maven version

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -9,7 +9,7 @@ Building
 Prerequisites:
 
 * JDK8+
-* Maven 3.0.3+
+* Maven 3.0.5+
 
 Run the full build:
 


### PR DESCRIPTION
Following is reported with earlier mavens:

> [INFO] Error resolving version for 'org.asciidoctor:asciidoctor-maven-plugin': Plugin requires Maven version 3.0.5
