### PR TITLE
Fix java.lang.module.FindException ...

### DIFF
--- a/activationapi/pom.xml
+++ b/activationapi/pom.xml
@@ -34,7 +34,7 @@
             jakarta.activation
         </activation.extensionName>
         <activation.moduleName>
-            jakarta.activation
+            jakarta.activation.api
         </activation.moduleName>
         <activation.packages.export>
             jakarta.activation.*; version=${activation.spec.version},


### PR DESCRIPTION
... caused by jakarta and jakarta-api having the same module name.

Fixes https://github.com/eclipse-ee4j/jaf/issues/38.