### PR TITLE
Make the compiler arguments to Xlint valid xml

### DIFF
--- a/activation/pom.xml
+++ b/activation/pom.xml
@@ -73,10 +73,10 @@
 				too hard to fix for now
 			    -->
 			    <compilerArguments>
-				<Xlint:all/>
-				<Xlint:-rawtypes/>
-				<Xlint:-unchecked/>
-				<Xlint:-finally/>
+				<arg>-Xlint:all</arg>
+				<arg>-Xlint:-rawtypes</arg>
+				<arg>-Xlint:-unchecked</arg>
+				<arg>-Xlint:-finally</arg>
 			    </compilerArguments>
 			    <showWarnings>true</showWarnings>
 			</configuration>


### PR DESCRIPTION
Fixes 53

Signed-off-by: Warwick Hunter <whunter@anonyome.com>