### PR TITLE
JUnit dependency and maven-surefire-plugin removal from POMs

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -23,11 +23,3 @@ SPDX-License-Identifier: BSD-3-Clause
 The project maintains the following source code repositories:
 
 * https://github.com/eclipse-ee4j/jaf
-
-## Third-party Content
-
-This project leverages the following third party content.
-
-JUnit (4.12)
-
-* License: Eclipse Public License

--- a/activation/pom.xml
+++ b/activation/pom.xml
@@ -45,19 +45,6 @@
             </resource>
         </resources>
         <plugins>
-            <!--
-            Configure test plugin to find *TestSuite classes.
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*TestSuite.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
@@ -66,12 +53,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,6 @@
         <!--Maven plugins version-->
         <hk2.plugin.version>3.0.1</hk2.plugin.version>
         <spotbugs.plugin.version>4.2.0</spotbugs.plugin.version>
-        <!--Dependencies version-->
-        <junit.version>4.13.1</junit.version>
     </properties>
 
     <developers>
@@ -431,11 +429,6 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
                 </plugin>
@@ -521,12 +514,6 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                 <groupId>com.sun.activation</groupId>
                 <artifactId>jakarta.activation</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <!--Test dependencies-->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Because there are no any unit/integration tests in the project. JUnit dependency and maven-surefire-plugin are not needed in POM files.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>