### PR TITLE
Fixed RI service loading.

### DIFF
--- a/activation/pom.xml
+++ b/activation/pom.xml
@@ -61,6 +61,13 @@
                     <exclude>META-INF/*.default</exclude>
                 </excludes>
             </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>META-INF/*.default</include>
+                </includes>
+            </resource>
         </resources>
         <plugins>
             <plugin>

--- a/sun-activation-registry/src/main/java/module-info.java
+++ b/sun-activation-registry/src/main/java/module-info.java
@@ -12,4 +12,6 @@ module com.sun.activation.registries {
     exports com.sun.activation.registries;
     requires java.logging;
     requires transitive jakarta.activation;
+    provides jakarta.activation.spi.MailcapRegistryProvider with com.sun.activation.registries.MailcapRegistryProviderImpl;
+    provides jakarta.activation.spi.MimeTypeRegistryProvider with com.sun.activation.registries.MimeTypeRegistryProviderImpl;
 }


### PR DESCRIPTION
Default mime types and mailcap are kept in API module acording to https://jakarta.ee/specifications/activation/2.0/jakarta-activation-spec-2.0.html#the-commandmap-interface note in chapter 3.3
