### PR TITLE
Add the ability to the API consumers to load the API implementations …

### DIFF
--- a/api/src/main/java/jakarta/activation/MailcapCommandMap.java
+++ b/api/src/main/java/jakarta/activation/MailcapCommandMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -693,9 +693,19 @@ public class MailcapCommandMap extends CommandMap {
     }
 
     private MailcapRegistryProvider getImplementation() {
-        return FactoryFinder.find(MailcapRegistryProvider.class,
-                "com.sun.activation.registries.MailcapRegistryProviderImpl",
-                false);
+        if (System.getSecurityManager() != null) {
+            return AccessController.doPrivileged(new PrivilegedAction<MailcapRegistryProvider>() {
+                public MailcapRegistryProvider run() {
+                    return FactoryFinder.find(MailcapRegistryProvider.class,
+                            "com.sun.activation.registries.MailcapRegistryProviderImpl",
+                            false);
+                }
+            });
+        } else {
+            return FactoryFinder.find(MailcapRegistryProvider.class,
+                    "com.sun.activation.registries.MailcapRegistryProviderImpl",
+                    false);
+        }
     }
 
     /*

--- a/api/src/main/java/jakarta/activation/MimetypesFileTypeMap.java
+++ b/api/src/main/java/jakarta/activation/MimetypesFileTypeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,6 @@
 
 package jakarta.activation;
 
-import jakarta.activation.spi.MailcapRegistryProvider;
 import jakarta.activation.spi.MimeTypeRegistryProvider;
 
 import java.io.*;
@@ -386,9 +385,19 @@ public class MimetypesFileTypeMap extends FileTypeMap {
     }
 
     private MimeTypeRegistryProvider getImplementation() {
-        return FactoryFinder.find(MimeTypeRegistryProvider.class,
-                "com.sun.activation.registries.MimeTypeRegistryProviderImpl",
-                false);
+        if (System.getSecurityManager() != null) {
+            return AccessController.doPrivileged(new PrivilegedAction<MimeTypeRegistryProvider>() {
+                public MimeTypeRegistryProvider run() {
+                    return FactoryFinder.find(MimeTypeRegistryProvider.class,
+                            "com.sun.activation.registries.MimeTypeRegistryProviderImpl",
+                            false);
+                }
+            });
+        } else {
+            return FactoryFinder.find(MimeTypeRegistryProvider.class,
+                    "com.sun.activation.registries.MimeTypeRegistryProviderImpl",
+                    false);
+        }
     }
 
     /*


### PR DESCRIPTION
…by using a different protection domain when using with the security manager enabled

Fixes #94 by loading the implementation providers on a privileged block