### PR TITLE
Support Legacy and Jakarta-Prefixed Resource Files in JAF API with Legacy Precedence #186

### DIFF
--- a/api/src/main/java/jakarta/activation/MailcapRegistry.java
+++ b/api/src/main/java/jakarta/activation/MailcapRegistry.java
@@ -52,7 +52,7 @@ public interface MailcapRegistry {
     Map<String, List<String>> getMailcapFallbackList(String mime_type);
 
     /**
-     * Return all the MIME types known to this jakarta.mailcap file.
+     * Return all the MIME types known to this mailcap file.
      *
      * @return a String array of the MIME types
      */
@@ -67,7 +67,7 @@ public interface MailcapRegistry {
     String[] getNativeCommands(String mime_type);
 
     /**
-     * appendToMailcap: Append to this Mailcap DB, use the jakarta.mailcap
+     * appendToMailcap: Append to this Mailcap DB, use the mailcap
      * format:
      * Comment == "# <i>comment string</i>"
      * Entry == "mimetype;        javabeanclass"
@@ -76,7 +76,7 @@ public interface MailcapRegistry {
      * # this is a comment
      * image/gif       jaf.viewers.ImageViewer
      *
-     * @param    mail_cap    the jakarta.mailcap string
+     * @param    mail_cap    the mailcap string
      */
     void appendToMailcap(String mail_cap);
 }

--- a/api/src/main/java/jakarta/activation/MimeTypeRegistry.java
+++ b/api/src/main/java/jakarta/activation/MimeTypeRegistry.java
@@ -48,7 +48,7 @@ public interface MimeTypeRegistry {
     /**
      * Appends string of entries to the types registry
      *
-     * @param mime_types the jakarta.mime.types string
+     * @param mime_types the mime.types and jakarta.mime.types string
      */
     void appendToRegistry(String mime_types);
 }

--- a/doc/spec/JAF-2.2-changes.txt
+++ b/doc/spec/JAF-2.2-changes.txt
@@ -12,4 +12,23 @@ find more information about the bug reports at:
 The Jakarta Activation 2.2 requires Java SE 11 or later.  Jakarta Activation 2.2
 is part of Jakarta EE 12.
 
+===================================================================
 
+1.  Resource Loading Order
+----------------------------------------------------------------
+
+To maintain backward compatibility while supporting Jakarta-prefixed resources, Jakarta Activation 2.2 now loads both legacy and Jakarta-prefixed resources when they are present in the classpath.
+
+Legacy resources (without the jakarta. prefix) are given precedence if both forms exist.
+
+Jakarta-prefixed resources (jakarta.*) are also loaded to support migration.
+
+For example:
+
+If both mailcap and jakarta.mailcap exist, the entries from mailcap are applied first.
+
+If both mime.types and jakarta.mime.types exist, the entries from mime.types are applied first.
+
+This ensures that existing applications using legacy resources continue to function correctly, while allowing Jakarta-prefixed resources to be used alongside them.
+
+Over time, the legacy resources may be removed, leaving only the Jakarta-prefixed variants.


### PR DESCRIPTION
https://github.com/jakartaee/jaf-api/issues/186

In [this diff ](https://github.com/jakartaee/jaf-api/pull/181/files#diff-36e924b61eb13d4287d63abf7cfa99b4478a020bd72a233e07c13274adcd1160) is where I added the jakarta resources. It could help to review this PR.

Tested in angus-activation here: https://github.com/eclipse-ee4j/angus-activation/pull/60